### PR TITLE
Fix service unbinding on early exits

### DIFF
--- a/src/rabbitmq-smoke-tests/tests/smoke_tests.go
+++ b/src/rabbitmq-smoke-tests/tests/smoke_tests.go
@@ -35,6 +35,11 @@ var _ = Describe("Smoke tests", func() {
 				helper.EnableTLSForODB(serviceName)
 			}
 
+			defer func() {
+				By("unbinding the app")
+				helper.UnbindService(appName, serviceName)
+			}()
+
 			By("pushing and binding an app")
 			appURL := helper.PushAndBindApp(appName, serviceName, appPath)
 
@@ -45,9 +50,6 @@ var _ = Describe("Smoke tests", func() {
 			helper.SendMessage(appURL, queue, "bar")
 			Expect(helper.ReceiveMessage(appURL, queue)).To(Equal("foo"))
 			Expect(helper.ReceiveMessage(appURL, queue)).To(Equal("bar"))
-
-			By("unbinding the app")
-			helper.UnbindService(appName, serviceName)
 		}
 	}
 


### PR DESCRIPTION
Hi,

While working on issue #3, I found out that service unbinding is flawed in case of early exits, like when a failure occurs.

Indeed, the unbinding should occur in a deferred function.

Here I'm suggesting a simple fix for this issue.

Best,
Benjamin