### PR TITLE
Update vendored Go modules for pivotal-cf/cf-rabbitmq-smoke-tests-release

### DIFF
--- a/src/rabbitmq-smoke-tests/go.mod
+++ b/src/rabbitmq-smoke-tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	github.com/pborman/uuid v1.2.0
-	golang.org/x/net v0.0.0-20190125002852-4b62a64f59f7 // indirect
+	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/src/rabbitmq-smoke-tests/go.sum
+++ b/src/rabbitmq-smoke-tests/go.sum
@@ -31,6 +31,8 @@ golang.org/x/net v0.0.0-20190119204137-ed066c81e75e h1:MDa3fSUp6MdYHouVmCCNz/zaH
 golang.org/x/net v0.0.0-20190119204137-ed066c81e75e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125002852-4b62a64f59f7 h1:F5FmzXi5B/brWpyRV/LcOMeNw1iKcqFh4pqGzCSLqSE=
 golang.org/x/net v0.0.0-20190125002852-4b62a64f59f7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
+golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180427151831-cbbc999da32d h1:50dJ9HJTx71MG4/LtVzB2w2xMeaNkxpZbrrro/cHSII=

--- a/src/rabbitmq-smoke-tests/vendor/golang.org/x/net/html/parse.go
+++ b/src/rabbitmq-smoke-tests/vendor/golang.org/x/net/html/parse.go
@@ -1719,8 +1719,12 @@ func inSelectIM(p *parser) bool {
 			}
 			p.addElement()
 		case a.Select:
-			p.tok.Type = EndTagToken
-			return false
+			if p.popUntil(selectScope, a.Select) {
+				p.resetInsertionMode()
+			} else {
+				// Ignore the token.
+				return true
+			}
 		case a.Input, a.Keygen, a.Textarea:
 			if p.elementInScope(selectScope, a.Select) {
 				p.parseImpliedToken(EndTagToken, a.Select, a.Select.String())
@@ -1750,6 +1754,9 @@ func inSelectIM(p *parser) bool {
 		case a.Select:
 			if p.popUntil(selectScope, a.Select) {
 				p.resetInsertionMode()
+			} else {
+				// Ignore the token.
+				return true
 			}
 		case a.Template:
 			return inHeadIM(p)
@@ -1775,13 +1782,22 @@ func inSelectInTableIM(p *parser) bool {
 	case StartTagToken, EndTagToken:
 		switch p.tok.DataAtom {
 		case a.Caption, a.Table, a.Tbody, a.Tfoot, a.Thead, a.Tr, a.Td, a.Th:
-			if p.tok.Type == StartTagToken || p.elementInScope(tableScope, p.tok.DataAtom) {
-				p.parseImpliedToken(EndTagToken, a.Select, a.Select.String())
-				return false
-			} else {
+			if p.tok.Type == EndTagToken && !p.elementInScope(tableScope, p.tok.DataAtom) {
 				// Ignore the token.
 				return true
 			}
+			// This is like p.popUntil(selectScope, a.Select), but it also
+			// matches <math select>, not just <select>. Matching the MathML
+			// tag is arguably incorrect (conceptually), but it mimics what
+			// Chromium does.
+			for i := len(p.oe) - 1; i >= 0; i-- {
+				if n := p.oe[i]; n.DataAtom == a.Select {
+					p.oe = p.oe[:i]
+					break
+				}
+			}
+			p.resetInsertionMode()
+			return false
 		}
 	}
 	return inSelectIM(p)

--- a/src/rabbitmq-smoke-tests/vendor/modules.txt
+++ b/src/rabbitmq-smoke-tests/vendor/modules.txt
@@ -52,7 +52,7 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 # github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid
-# golang.org/x/net v0.0.0-20190125002852-4b62a64f59f7
+# golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 golang.org/x/net/html/charset
 golang.org/x/net/html
 golang.org/x/net/html/atom


### PR DESCRIPTION
This PR updates the vendored Go modules of pivotal-cf/cf-rabbitmq-smoke-tests-release