### PR TITLE
Deploy the test app with the given apps domain

### DIFF
--- a/src/rabbitmq-smoke-tests/tests/helper/cf.go
+++ b/src/rabbitmq-smoke-tests/tests/helper/cf.go
@@ -66,8 +66,8 @@ func DeleteSecurityGroup(securityGroupName string) {
 	Expect(Cf("delete-security-group", securityGroupName, "-f")).To(gexec.Exit(0))
 }
 
-func PushAndBindApp(appName, serviceName, testAppPath string) string {
-	Expect(Cf("push", "-f", filepath.Join(testAppPath, "manifest.yml"), "--no-start", "--random-route", appName)).To(gexec.Exit(0))
+func PushAndBindApp(appName, serviceName, testAppPath, appsDomain string) string {
+	Expect(Cf("push", "-f", filepath.Join(testAppPath, "manifest.yml"), "-d", appsDomain, "--no-start", "--random-route", appName)).To(gexec.Exit(0))
 	Expect(Cf("bind-service", appName, serviceName)).To(gexec.Exit(0))
 	Expect(Cf("start", appName)).To(gexec.Exit(0))
 	return LookupAppURL(appName)

--- a/src/rabbitmq-smoke-tests/tests/smoke_tests.go
+++ b/src/rabbitmq-smoke-tests/tests/smoke_tests.go
@@ -55,7 +55,7 @@ var _ = Describe("Smoke tests", func() {
 			}()
 
 			By("pushing and binding an app")
-			appURL := helper.PushAndBindApp(appName, serviceName, appPath)
+			appURL := helper.PushAndBindApp(appName, serviceName, appPath, testConfig.AppsDomain)
 
 			By("sending and receiving rabbit messages")
 			queue := fmt.Sprintf("%s-queue", appName)


### PR DESCRIPTION
Signed-off-by: Holly Kamionka <hkamj@allstate.com>

Leverages the existing apps_domain option to deploy the app with that domain. This is useful for us because the default domain can be one that is inaccessible depending on the isolation segment the org/space is in.