### PR TITLE
Make smoke tests log into a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ config/private.yml
 *.a
 *.so
 
+# Local configuration files
+src/rabbitmq-smoke-tests/assets/*.json
+!src/rabbitmq-smoke-tests/assets/example_config.json
+
+# Goland IDE
+.idea/
+
 # Folders
 _obj
 _test

--- a/jobs/on-demand-broker-smoke-tests/templates/run.sh
+++ b/jobs/on-demand-broker-smoke-tests/templates/run.sh
@@ -17,8 +17,10 @@ export CONFIG_PATH="/var/vcap/jobs/on-demand-broker-smoke-tests/config.json"
 export CGO_ENABLED=0
 export SMOKE_TESTS_TIMEOUT=1h
 
+export SMOKE_TESTS_BASE_LOG_DIR="/var/vcap/sys/log/on-demand-broker-smoke-tests"
+
 pushd ${PACKAGE_DIR}
   echo "Running on-demand smoke tests"
   # Disbale Go modules and cgo to avoid issue https://github.com/golang/go/issues/26988
-  CGO_ENABLED=0 ginkgo -p -v --trace --randomize-suites --randomize-all --keep-going --timeout="$SMOKE_TESTS_TIMEOUT" --fail-on-pending tests
+  CGO_ENABLED=0 ginkgo -p --no-color --succinct --trace --randomize-suites --randomize-all --keep-going --timeout="$SMOKE_TESTS_TIMEOUT" --fail-on-pending tests
 popd

--- a/src/rabbitmq-smoke-tests/Makefile
+++ b/src/rabbitmq-smoke-tests/Makefile
@@ -22,4 +22,4 @@ go-vet:
 	go vet `go list ./... | grep -v vendor`
 
 test:
-	ginkgo -v --trace --randomize-suites --randomize-all --keep-going --fail-on-pending tests
+	ginkgo --no-color --succinct --trace --randomize-suites --randomize-all --keep-going --fail-on-pending tests

--- a/src/rabbitmq-smoke-tests/tests/helper/service_key.go
+++ b/src/rabbitmq-smoke-tests/tests/helper/service_key.go
@@ -2,38 +2,37 @@ package helper
 
 import (
 	"encoding/json"
-	"regexp"
-
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"regexp"
 )
 
 var serviceKeyHeader = regexp.MustCompile(`^\s*Getting key .*`)
 
 type ServiceKey struct {
-	DashboardUrl string                            `json:"dashboard_url"`
-	Username     string                            `json:"username"`
-	Password     string                            `json:"password"`
-	Hostname     string                            `json:"hostname"`
-	Hostnames    []string                          `json:"hostnames"`
-	HttpApiUri   string                            `json:"http_api_uri"`
-	HttpApiUris  []string                          `json:"http_api_uris"`
-	URI          string                            `json:"uri"`
-	URIs         []string                          `json:"uris"`
-	VHOST        string                            `json:"vhost"`
-	SSL          bool                              `json:"ssl"`
-	Protocols    map[string]map[string]interface{} `json:"protocols"`
+	DashboardUrl string                    `json:"dashboard_url"`
+	Username     string                    `json:"username"`
+	Password     string                    `json:"password"`
+	Hostname     string                    `json:"hostname"`
+	Hostnames    []string                  `json:"hostnames"`
+	HttpApiUri   string                    `json:"http_api_uri"`
+	HttpApiUris  []string                  `json:"http_api_uris"`
+	URI          string                    `json:"uri"`
+	URIs         []string                  `json:"uris"`
+	VHOST        string                    `json:"vhost"`
+	SSL          bool                      `json:"ssl"`
+	Protocols    map[string]map[string]any `json:"protocols"`
 }
 
 func GetServiceKey(serviceName, keyName string) ServiceKey {
-	session := Cf("service-key", serviceName, keyName)
+	// this function only works with CF CLI v7. CF CLI v8 changed the format of the service key
+	session := CfWithBufferedOutput("service-key", serviceName, keyName)
 	Expect(session).To(gexec.Exit(0))
 
 	chopped := serviceKeyHeader.ReplaceAllLiteral(session.Buffer().Contents(), []byte{})
 
 	var serviceKey ServiceKey
-	err := json.Unmarshal(chopped, &serviceKey)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(json.Unmarshal(chopped, &serviceKey)).To(Succeed())
 
 	return serviceKey
 }


### PR DESCRIPTION
From Bosh.io docs: https://bosh.io/docs/errands/

> Errand output is limited to one megabyte of data.
> If the response is larger an error will be returned instead.
> Release authors should ensure the full error is properly logged
> to disk and a summary is returned as output.

This commit makes smoke tests log to a file, in addition to the standard
output. Now, the standard output is a small summary, and the log file
has every single line captured by Ginkgo writer.

This commit also changes the step where we get a service key, so that it
does not print the service key. The service key has credentials that are
temporary for the smoke tests, however, we should not log credentials to
any output.

