### PR TITLE
TNZ-38100: updates the bucket-name due to gcp-migration

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -4,4 +4,4 @@ min_cli_version: 1.2690.0
 blobstore:
   provider: gcs
   options:
-    bucket_name: cf-rabbitmq-smoke-tests-bosh-release-blobs
+    bucket_name: cf-rmq-smoke-tests-bosh-release-blobs


### PR DESCRIPTION
Bucket name change:
cf-rabbitmq-smoke-tests-bosh-release-blobs -> cf-rmq-smoke-tests-bosh-release-blobs