### PR TITLE
TNZ-42959: Filter smoke tests plans based on run_smoke_tests property

### DIFF
--- a/jobs/on-demand-broker-smoke-tests/templates/config.json.erb
+++ b/jobs/on-demand-broker-smoke-tests/templates/config.json.erb
@@ -20,7 +20,7 @@ conf = {
   timeout_scale: 30.0,
   skip_ssl_validation: true,
   service_offering: p("cf.service_offering_name"),
-  plans: p("cf.plans").reject { |plan| plan.nil? },
+  plans: p("cf.plans").reject { |plan| plan.key?("run_smoke_tests") && plan["run_smoke_tests"] != true },
   tls_support: p("tls_support"),
   oauth_enforced: p("oauth_enforced"),
 }


### PR DESCRIPTION
This PR contains following commits:

* b0c7b58 TNZ-42959: spec tests for smoke tests plan property run_smoke_tests
* d86d6cf TNZ-42959: filters the smoke tests plans based on run_smoke_tests to run smoke-tests 
    - based on run_smoke_tests property, select plan for which run_smoke_tests is set to true   to run smoke-tests