### PR TITLE
TNZ-74274: use tanzu-cf-cli

### DIFF
--- a/jobs/on-demand-broker-smoke-tests/templates/run.sh.erb
+++ b/jobs/on-demand-broker-smoke-tests/templates/run.sh.erb
@@ -3,7 +3,7 @@ set -ex
 
 export GOROOT=$(readlink -nf /var/vcap/packages/cf-rabbitmq-smoke-tests-golang)
 export GOPATH=/var/vcap/packages/cf-rabbitmq-smoke-tests
-export PATH=/var/vcap/packages/cf-cli-8-linux/bin:$GOPATH/bin:$GOROOT/bin:$PATH
+export PATH=/var/vcap/packages/tanzu-cf-cli-linux/bin:/var/vcap/packages/cf-cli-8-linux/bin:$GOPATH/bin:$GOROOT/bin:$PATH
 
 export GOCACHE=$PWD/cache
 

--- a/jobs/smoke-tests/templates/run.sh
+++ b/jobs/smoke-tests/templates/run.sh
@@ -6,7 +6,7 @@ set -e
 
 export GOROOT=$(readlink -nf /var/vcap/packages/cf-rabbitmq-smoke-tests-golang)
 export GOPATH=/var/vcap/packages/cf-rabbitmq-smoke-tests
-export PATH=/var/vcap/packages/cf-cli-8-linux/bin:$GOPATH/bin:$GOROOT/bin:$PATH
+export PATH=/var/vcap/packages/tanzu-cf-cli-linux/bin:/var/vcap/packages/cf-cli-8-linux/bin:$GOPATH/bin:$GOROOT/bin:$PATH
 export PACKAGE_DIR=/var/vcap/packages/cf-rabbitmq-smoke-tests/src/rabbitmq-smoke-tests
 
 export GOCACHE=$PWD/cache


### PR DESCRIPTION
> Adding both **tanzu-cf-cli** and **cf-cli-8-linux** in path for backward compatibility with old brokers as this release is common